### PR TITLE
fix: add onStop to re-enable mapPan on exit

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -72,4 +72,11 @@ FreehandMode.simplify = function(polygon) {
   });
 }
 
+FreehandMode.onStop = function () {
+  setTimeout(() => {
+    if (!this.map || !this.map.dragPan) return;
+    this.map.dragPan.enable();
+  }, 0);
+};
+  
 export default FreehandMode


### PR DESCRIPTION
Added `onStop` lifecycle method(according to [the doc](https://github.com/mapbox/mapbox-gl-draw/blob/main/docs/MODES.md#modeonstop)) to re-enable panning of map when exit mode.

In `onSetup` lifecycle method it disabled mapPan, but did not enable it. This cause problems when user switch to other modes like the `static` as panning is no longer working. 