### PR TITLE
fix: regression caused by missing DrawPolygon.onStop

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -72,7 +72,8 @@ FreehandMode.simplify = function(polygon) {
   });
 }
 
-FreehandMode.onStop = function () {
+FreehandMode.onStop = function (state) {
+  DrawPolygon.call(this, state)
   setTimeout(() => {
     if (!this.map || !this.map.dragPan) return;
     this.map.dragPan.enable();


### PR DESCRIPTION
This is to fix a regression introduced in previous PR #15, in which I added `onStop` method, but missed that it needs to call the `onStop` from `DrawPolygon`. Otherwise the `draw.create` event cannot be fired properly. Thanks.
