### PR TITLE
Fix for fix in (#16) where DrawPolygon.onStop is improperly called.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/bemky/mapbox-gl-draw-free-mode#readme",
   "devDependencies": {
+    "@rollup/plugin-terser": "^0.4.3",
     "webpack": "^5.38.1",
     "webpack-cli": "^4.7.2",
     "webpack-dev-server": "^3.11.2"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,23 @@
+import terser from '@rollup/plugin-terser';
+
+export default {
+	input: 'src/index.js',
+	output: {
+		name: 'FreehandMode',
+		format: 'iife',
+		file: 'dist/mapbox-gl-draw-freehand-mode.js',
+		globals: {
+        	'@mapbox/mapbox-gl-draw/src/modes/draw_polygon': 'MapboxDraw.modes.draw_polygon',
+        	'@mapbox/mapbox-gl-draw/src/constants': 'MapboxDraw.constants',
+        	'@turf/simplify': 'turf.simplify',
+		},
+		plugins: [
+			terser()
+		],
+	},
+	external: [
+		'@mapbox/mapbox-gl-draw/src/modes/draw_polygon',
+		'@mapbox/mapbox-gl-draw/src/constants',
+		'@turf/simplify'
+	]
+};

--- a/src/index.js
+++ b/src/index.js
@@ -73,7 +73,7 @@ FreehandMode.simplify = function(polygon) {
 }
 
 FreehandMode.onStop = function (state) {
-  DrawPolygon.call(this, state)
+  DrawPolygon.onStop.call(this, state)
   setTimeout(() => {
     if (!this.map || !this.map.dragPan) return;
     this.map.dragPan.enable();


### PR DESCRIPTION
Add rollup config to build a useful browser dist.